### PR TITLE
feat: added ledger query support

### DIFF
--- a/asset-transfer-modified/META-INF/statedb/couchdb/indexes/indexOwner.json
+++ b/asset-transfer-modified/META-INF/statedb/couchdb/indexes/indexOwner.json
@@ -1,0 +1,1 @@
+{"index":{"fields":["docType","owner"]},"ddoc":"indexOwnerDoc", "name":"indexOwner","type":"json"}

--- a/asset-transfer-modified/src/health-chaincode.ts
+++ b/asset-transfer-modified/src/health-chaincode.ts
@@ -13,23 +13,24 @@ import stringify from "json-stringify-deterministic";
 import sortKeysRecursive from "sort-keys-recursive";
 import { Asset } from "./asset";
 
-// type AssetType = {
-//     ID: string;
-//     Name: string;
-//     Type: string;
-//     IpAddress: string;
-//     Available: boolean;
-//     LastUpdate: number;
-//     IsWearable: boolean;
-//     GPSLocation: string;
-//     Owner: OwnerType;
-// }
+type AssetType = {
+    ID: string;
+    Name: string;
+    Type: string;
+    IpAddress: string;
+    Available: boolean;
+    LastUpdate: number;
+    IsWearable: boolean;
+    GPSLocation: string;
+    Owner: OwnerType;
+}
 
-// type OwnerType = {
-//     Hospital: string;
-//     Department: string;
-//     ContactPerson: string;
-// }
+type OwnerType = {
+    Hospital: string;
+    Department: string;
+    ContactPerson: string;
+    OwnerClientID: string;
+}
 
 @Info({
   title: "Health Chaincode",
@@ -136,8 +137,8 @@ export class HealthAssetTransferContract extends Contract {
     contactPerson: string
   ): Promise<void> {
     // Atrtribute based access control
-    const err = ctx.clientIdentity.assertAttributeValue("abac.creator", "true");
-    if (err) {
+    const attrRes = ctx.clientIdentity.assertAttributeValue("abac.creator", "true");
+    if (!attrRes) {
       throw new Error(`Client is not authorized to create an asset`);
     }
 
@@ -145,6 +146,8 @@ export class HealthAssetTransferContract extends Contract {
     if (exists) {
       throw new Error(`The asset ${id} already exists`);
     }
+
+    const ownerClientID = ctx.clientIdentity.getID();
 
     const asset = {
       ID: id,
@@ -159,14 +162,14 @@ export class HealthAssetTransferContract extends Contract {
         Hospital: hospital,
         Department: department,
         ContactPerson: contactPerson,
-        OwnerClientID: ctx.clientIdentity.getID(), // get the client ID from the transaction context -> this is the client ID of the creator
+        OwnerClientID: ownerClientID, // get the client ID from the transaction context -> this is the client ID of the creator
       },
     };
 
     // emit event
-    const eventPayload = JSON.stringify({
+    const eventPayload = stringify({
         asset: asset,
-        requestedBy: ctx.clientIdentity.getID(),
+        requestedBy: ownerClientID,
         action: 'Write'
     })
     ctx.stub.setEvent("CreateAsset", Buffer.from(eventPayload));
@@ -176,6 +179,12 @@ export class HealthAssetTransferContract extends Contract {
       id,
       Buffer.from(stringify(sortKeysRecursive(asset)))
     );
+
+    // save to db
+    let indexName = 'indexOwner';
+    let indexKey = await ctx.stub.createCompositeKey(indexName, [asset.ID, ownerClientID])
+
+    await ctx.stub.putState(indexKey, Buffer.from('\u0000'));
   }
 
   // UpdateAsset updates an existing asset in the world state with provided parameters.
@@ -199,10 +208,12 @@ export class HealthAssetTransferContract extends Contract {
       throw new Error(`The asset ${id} does not exist`);
     }
 
+    const clientID = ctx.clientIdentity.getID();
+
     const clientIsOwner = await this.ClientIsOwner(ctx, id);
     if (!clientIsOwner) {
       throw new Error(
-        `The asset ${id} is not owned by the client ${ctx.clientIdentity.getID()}`
+        `The asset ${id} is not owned by the client ${clientID}`
       );
     }
 
@@ -220,14 +231,14 @@ export class HealthAssetTransferContract extends Contract {
         Hospital: hospital,
         Department: department,
         ContactPerson: contactPerson,
-        OwnerClientID: ctx.clientIdentity.getID(), // could also be taken from the original asset
+        OwnerClientID: clientID, // could also be taken from the original asset
       },
     };
 
     // emit event
-    const eventPayload = JSON.stringify({
+    const eventPayload = stringify({
         asset: updatedAsset,
-        requestedBy: ctx.clientIdentity.getID(),
+        requestedBy: clientID,
         action: 'Write'
     })
     ctx.stub.setEvent("UpdateAsset", Buffer.from(eventPayload));
@@ -242,28 +253,43 @@ export class HealthAssetTransferContract extends Contract {
   // DeleteAsset deletes an given asset from the world state.
   @Transaction()
   public async DeleteAsset(ctx: Context, id: string): Promise<void> {
+    if (!id) {
+	throw new Error('Asset name must not be empty');
+    }
+
     const exists = await this.AssetExists(ctx, id);
     if (!exists) {
       throw new Error(`The asset ${id} does not exist`);
     }
 
+    const clientID = ctx.clientIdentity.getID();
+
     const clientIsOwner = await this.ClientIsOwner(ctx, id);
     if (!clientIsOwner) {
       throw new Error(
-        `The asset ${id} is not owned by the client ${ctx.clientIdentity.getID()}`
+        `The asset ${id} is not owned by the client ${clientID}`
       );
     }
 
     // emit event
     const asset = await this.ReadAsset(ctx, id);
-    const eventPayload = JSON.stringify({
+    const eventPayload = stringify({
         asset: asset,
-        requestedBy: ctx.clientIdentity.getID(),
+        requestedBy: clientID,
         action: 'Write'
     })
     ctx.stub.setEvent("DeleteAsset", Buffer.from(eventPayload));
 
     return ctx.stub.deleteState(id);
+
+    // delete the index
+    let indexName = 'indexOwner';
+    let indexKey = ctx.stub.createCompositeKey(indexName, [id, clientID])
+    if (!indexKey) {
+	throw new Error('Failed to create createCompositeKey');
+    }
+    // Delete index entry to state
+    await ctx.stub.deleteState(indexKey);
   }
 
   // TransferAsset updates the owner field of asset with given id in the world state, and returns the old owner.
@@ -291,7 +317,7 @@ export class HealthAssetTransferContract extends Contract {
     asset.Owner.OwnerClientID = newOwner;
 
     // emit event
-    const eventPayload = JSON.stringify({
+    const eventPayload = stringify({
         asset: asset,
         requestedBy: ctx.clientIdentity.getID(),
         action: 'Write'
@@ -315,7 +341,7 @@ export class HealthAssetTransferContract extends Contract {
     }
 
     // emit event for read
-    const eventPayload = JSON.stringify({
+    const eventPayload = stringify({
         asset: assetJSON,
         requestedBy: ctx.clientIdentity.getID(),
         action: 'Read'
@@ -348,14 +374,56 @@ export class HealthAssetTransferContract extends Contract {
     }
 
     // emit event for read
-    const eventPayload = JSON.stringify({
+    const eventPayload = stringify({
         asset: allResults,
         requestedBy: ctx.clientIdentity.getID(),
         action: 'Read'
     })
     ctx.stub.setEvent("GetAllAssets", Buffer.from(eventPayload));
     
-    return JSON.stringify(allResults);
+    return stringify(allResults);
+  }
+
+  @Transaction()
+  public async QueryAssets(ctx: Context, queryString: string): Promise<string> {
+    let resultsIterator = await ctx.stub.getQueryResult(queryString);
+    let results = await this.GetAllResults(resultsIterator, false);
+
+    return stringify(results);
+  }
+
+  // Iterator here is of type StateQueryIterator, but contract-api won't import that type
+  private async GetAllResults(iterator: any, isHistory: boolean): Promise<any[]> {
+        let allResults = [];
+	let res = await iterator.next();
+	while (!res.done) {
+		if (res.value && res.value.value.toString()) {
+			let jsonRes: any = {};
+			console.log(res.value.value.toString('utf8'));
+			if (isHistory && isHistory === true) {
+				jsonRes.TxId = res.value.txId;
+				jsonRes.Timestamp = res.value.timestamp;
+				try {
+					jsonRes.Value = JSON.parse(res.value.value.toString('utf8'));
+				} catch (err) {
+					console.log(err);
+					jsonRes.Value = res.value.value.toString('utf8');
+				}
+			} else {
+				jsonRes.Key = res.value.key;
+				try {
+					jsonRes.Record = JSON.parse(res.value.value.toString('utf8'));
+				} catch (err) {
+					console.log(err);
+					jsonRes.Record = res.value.value.toString('utf8');
+				}
+			}
+			allResults.push(jsonRes);
+		}
+		res = await iterator.next();
+	}
+	iterator.close();
+	return allResults;
   }
 
   // AssetExists returns true when asset with given ID exists in world state.


### PR DESCRIPTION
# Feature
Added super basic ledger query support: added test index for id and generic QueryAsset function on the chaincode that takes a CouchDB query. Can be called like below:
```
peer chaincode query -C mychannel -n ledger -c '{"function":"QueryAssets","Args":["{\"selector\":{\"_id\":\"assetid1\"}}"]}'
```

# Test
No unit tests but can be replicated with the commands below. Prereqs: ``curl``, ``git``, ``docker``.

Fabric samples can be installed using the commands below:

```bash
curl -sSLO https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/install-fabric.sh && chmod +x install-fabric.sh
./install.sh
```

Navigate to the fabric-samples/test-network directory and execute the commands below. The commands below should be run in ``fabric-samples/test-network``. Dont just copy the second command, edit it to match your directory of the asset-transfer-modified directory (or any other chaincodebase). Also run ``npm install`` in that directory first.

```bash
# Set up channel (Docker)
./network.sh up createChannel -s couchdb -ca
# DONT COPY BELOW, EDIT TO MATCH YOUR PATH TO THE CODE
./network.sh deployCC -ccn ledger -ccp ~/health-1-hyperledger/asset-transfer-modified/ -ccl typescript -ccep "OR('Org1MSP.peer','Org2MSP.peer')"

# Some environmental variables to perform actions using Org1
export PATH=${PWD}/../bin:${PWD}:$PATH
export FABRIC_CFG_PATH=$PWD/../config/

export CORE_PEER_TLS_ENABLED=true
export CORE_PEER_LOCALMSPID="Org1MSP"
export CORE_PEER_MSPCONFIGPATH=${PWD}/organizations/peerOrganizations/org1.example.com/users/creator1@org1.example.com/msp
export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
export CORE_PEER_ADDRESS=localhost:7051
export TARGET_TLS_OPTIONS=(-o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem" --peerAddresses localhost:7051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt" --peerAddresses localhost:9051 --tlsRootCertFiles "${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt")

# Assign attribute to create assets
export FABRIC_CA_CLIENT_HOME=${PWD}/organizations/peerOrganizations/org1.example.com/
fabric-ca-client register --id.name creator1 --id.secret creator1pw --id.type client --id.affiliation org1 --id.attrs 'abac.creator=true:ecert' --tls.certfiles "${PWD}/organizations/fabric-ca/org1/tls-cert.pem"
fabric-ca-client enroll -u https://creator1:creator1pw@localhost:7054 --caname ca-org1 -M "${PWD}/organizations/peerOrganizations/org1.example.com/users/creator1@org1.example.com/msp" --tls.certfiles "${PWD}/organizations/fabric-ca/org1/tls-cert.pem"
cp "${PWD}/organizations/peerOrganizations/org1.example.com/msp/config.yaml" "${PWD}/organizations/peerOrganizations/org1.example.com/users/creator1@org1.example.com/msp/config.yaml"

# Create asset and query for it
peer chaincode invoke "${TARGET_TLS_OPTIONS[@]}" -C mychannel -n ledger -c '{"function":"CreateAsset","Args":["assetid1","assetname1","Wearable","0.0.0.0","false","0","true","no location","Meander","oncology","jaylan"]}'
peer chaincode query -C mychannel -n ledger -c '{"function":"QueryAssets","Args":["{\"selector\":{\"_id\":\"assetid1\"}}"]}'
```

You can then access CouchDB interface by going to ``localhost:5984/_utils`` -> login using ``admin`` and ``adminpw``

To take down the network:

```
./network.sh down
```

# Future 
Might add additional parametrized functions that actively use index or perform specific queries.